### PR TITLE
Fix VM reboot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,4 +21,12 @@ Vagrant.configure(2) do |config|
     ansible.playbook = "configure.yml"
   end
 
+  # During Ansible provisioning, a mounted binding is created from the
+  # the virtual machine to the shared folder in order to store the project
+  # Node modules in the VM. The following provisioner ensures that this binding
+  # is preserved on subsequent boots of the VM.
+  config.vm.provision "shell", privileged: true, run: "always" do |shell|
+    shell.inline = "mount --bind /home/vagrant/node_modules /vagrant/client/node_modules"
+  end
+
 end

--- a/server/provision/roles/npm-frontend/tasks/main.yml
+++ b/server/provision/roles/npm-frontend/tasks/main.yml
@@ -7,7 +7,7 @@
   file: "path={{ frontend }}/node_modules state=directory"
 
 - name: Mount node_modules from VM onto shared folder.
-  mount: "src={{ frontend_packages }} name={{ frontend }}/node_modules opts='bind' fstype=none state=mounted"
+  shell: "mount --bind {{ frontend_packages }} {{ frontend }}/node_modules"
   become: yes
   become_method: sudo
 


### PR DESCRIPTION
Avoid writing node_modules mount to fstab due to unexpected Vagrant behavior, instead just perform the binding at provision time on every boot.